### PR TITLE
feat(UnitTesting): Make PDM optional

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -30,7 +30,7 @@ on:
         required: true
         type: string
       requirements:
-        description: 'Python dependencies to be installed through pip.'
+        description: 'Additional python pre-requisite dependencies to be installed through pip.'
         required: false
         default: ''
         type: string
@@ -39,8 +39,23 @@ on:
         required: false
         default: 'pdm run -v test -svvv -rA'
         type: string
+      use_pdm:
+        description: "Does this project use PDM?"
+        required: false
+        default: true
+        type: boolean
+      install_command:
+        description: "Install dependencies if not using PDM"
+        required: false
+        default: 'pip install'
+        type: string
       artifact:
         description: "Generate unit test report with junitxml and upload results as an artifact."
+        required: false
+        default: ''
+        type: string
+      run_system:
+        description: 'Additional dependecies or custom system commands to run'
         required: false
         default: ''
         type: string
@@ -64,18 +79,55 @@ jobs:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
+      # Set up if we're not using PDM
+      - name: 🐍 Setup Python ${{ matrix.python }}
+        if: inputs.use_pdm != 'true'
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: ⚙️ Install system dependencies
+        if: inputs.run_system != ''
+        run: ${{ inputs.run_system }}
+
+      - name: ⚙️ Update pip
+        if: inputs.use_pdm != 'true'
+        run: python -m pip install -U pip
+
+      - name: 🔧 Install wheel and pip dependencies
+        if: inputs.use_pdm != 'true'
+        run: |
+          python -m pip install -U wheel ${{ inputs.requirements }}
+
+      - name: ⚙️ Set up cache
+        id: cache_not_pdm
+        if: inputs.use_pdm != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ matrix.python }}-${{ hashFiles('**/Pipfile.lock') }}
+
+      - name: 🔧Install dependencies
+        if: inputs.use_pdm != 'true' && steps.cache_not_pdm.outputs.cache-hit != 'true'
+        run: |
+          pipenv install --skip-lock --dev
+
+      # Set up if we're using PDM
       - name: 🐍 Set up PDM
+        if: inputs.use_pdm == 'true'
         uses: pdm-project/setup-pdm@v2
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚙️ Set cache variables
+        if: inputs.use_pdm == 'true'
         id: set_variables
         run: |
           echo "::set-output name=PIP_CACHE::$(pip cache dir)"
           echo "::set-output name=PDM_CACHE::$(pdm config cache_dir)"
 
       - name: ⚙️ Set up cache
+        if: inputs.use_pdm == 'true'
         uses: actions/cache@v2
         with:
           path: |
@@ -84,11 +136,12 @@ jobs:
           key: tests-cache-${{ runner.os }}-${{ matrix.python }}
 
       - name: 🔧 Install dependencies
-        if: matrix.system != 'msys2'
+        if: inputs.use_pdm == 'true'
         run: |
           pdm use -f ${{ matrix.python }}
           pdm install -dG test
 
+      # Run for PDM or pip
       - name: ☑  Run unit tests
         if: matrix.system == 'windows'
         run: |


### PR DESCRIPTION
Adds a `use_pdm` flag; if true (default), the Action will install and run the package with PDM. If false, `install_command` will run, defaulting to "pip install". 

Also adds a hook for arbitrary system calls, i.e. for installing a debian package. 

An example for using pipenv with an external dependency install from Github:

```bash
  UnitTesting:
    uses: zeit-medical/github-actions/.github/workflows/UnitTesting.yml@dev
    needs:
      - Params
    with:
      jobs: ${{ needs.Params.outputs.python_jobs }}
      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
      run_system: |
        TEMP_DEB="$(mktemp)" &&
        wget -O "$TEMP_DEB" 'https://github.com/sccn/liblsl/releases/download/v1.16.0/liblsl-1.16.0-bionic_amd64.deb' &&
        sudo dpkg -i "$TEMP_DEB"
        rm -f "$TEMP_DEB"
      test_command: 'pipenv run pytest -svvv -rA'
      requirements: 'pipenv'
      use_pdm: false
      install_command: pipenv install --dev
```